### PR TITLE
Checkbox for is_multiline u layout editor-u

### DIFF
--- a/backend/src/controllers/documentLayout.controller.ts
+++ b/backend/src/controllers/documentLayout.controller.ts
@@ -281,7 +281,7 @@ class DocumentLayoutsController {
     try {
 
       // Obrišimo document layout
-      const [numberOfDeletedDocumentLayouts] = await db.document_layouts.destroy({ where: { id: layoutID }, individualHooks: true });
+      const numberOfDeletedDocumentLayouts = await db.document_layouts.destroy({ where: { id: layoutID }, individualHooks: true });
 
       if (numberOfDeletedDocumentLayouts === 0) {
         console.error(`Failed to delete document layout with ID ${layoutID}`);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -45,3 +45,9 @@
   box-shadow: 0 0 0 1px #14a538  !important;
 }
 
+.custom-checkbox .form-check-input {
+  border: 1px solid grey;   
+  border-radius: 4px;        
+  transform: scale(1.5);
+  transform-origin: center center;
+}

--- a/frontend/src/components/Annotation.tsx
+++ b/frontend/src/components/Annotation.tsx
@@ -18,6 +18,7 @@ export type AnnotationProps = {
     saved: boolean;
     isSelected?: boolean;
     onChange?: (newAttrs: ShapeProps) => void;
+    isMultiline: boolean;
 };
 
 // Annotation component
@@ -104,7 +105,8 @@ export const instanceHandleMouseDown = (event: any) => {   //to start drawing wh
         shapeProps: { x, y, width: 0, height: 0 },
         saved: false,
         isSelected: false,
-        onChange: () => {}
+        onChange: () => {},
+        isMultiline: false
     }];
 };
 
@@ -117,7 +119,8 @@ export const instanceHandleMouseMove = (event: any, newAnnotation: AnnotationPro
         shapeProps: { x: sx, y: sy, width: x - sx, height: y - sy },
         saved: false,
         isSelected: false,
-        onChange: () => {}
+        onChange: () => {},
+        isMultiline: false
       }];
     }
     return [];

--- a/frontend/src/components/DocumentLayoutCreate.tsx
+++ b/frontend/src/components/DocumentLayoutCreate.tsx
@@ -329,8 +329,6 @@ function DocumentLayoutCreate() {
     return img;   //this can now be used inside <Image> in react-konva
   }
 
-  const roundToTwo = (x: number) => Math.round(x * 100) / 100
-
   useEffect(() => {
     getDocumentTypes();
   }, []);
@@ -404,11 +402,12 @@ function DocumentLayoutCreate() {
         <Row className="d-flex flex-wrap justify-content-center align-items-start">
           {/* Canvas Column */}
           <Col
-            md={7}
+            md={6}
             className="responsive-col"
             style={{
               marginLeft: "50px",
               minWidth: `${canvasMeasures.width}px`,
+              marginRight: "20px",
             }}
           >
             <div
@@ -459,7 +458,7 @@ function DocumentLayoutCreate() {
 
           {/* Form Column */}
           <Col
-            md={5}
+            md={6}
             className="responsive-col mx-auto"
             style={{ width: "550px"}}
           >
@@ -514,7 +513,8 @@ function DocumentLayoutCreate() {
                         <th>#</th>
                         <th>Field Name</th>
                         <th>Field Coordinates</th>
-                        <th >Actions</th>
+                        <th>Actions</th>
+                        <th>Multi-line</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -525,12 +525,12 @@ function DocumentLayoutCreate() {
                             <td className="text-start align-middle">{index + 1}</td>
                             <td className="text-start align-middle">{annotation.name || "Unnamed Field"}</td>
                             <td className="text-start align-middle">
-                            ({roundToTwo(Number(annotation.shapeProps.x))}, {roundToTwo(Number(annotation.shapeProps.y))}),  
-                            ({roundToTwo(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {roundToTwo(Number(annotation.shapeProps.y))}) <br />
-                            ({roundToTwo(Number(annotation.shapeProps.x))}, {roundToTwo(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))}), 
-                            ({roundToTwo(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {roundToTwo(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))})
+                            ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y))}),  
+                            ({Math.round(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {Math.round(Number(annotation.shapeProps.y))}) <br />
+                            ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))}), 
+                            ({Math.round(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {Math.round(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))})
                             </td>
-                            <td className="text-center align-middle" style={{ whiteSpace: "nowrap" }}>
+                            <td className="text-center align-middle" style={{ whiteSpace: "nowrap", padding: "0px 5px" }}>
                             <Button 
                                 variant="primary"
                                 className="me-2"
@@ -555,6 +555,18 @@ function DocumentLayoutCreate() {
                               >
                                 Delete
                             </Button>
+                            </td>
+                            <td style={{ textAlign: "center", verticalAlign: "middle" }}>
+                            <Form.Check 
+                              type="checkbox"
+                              style={{ 
+                                transform: "scale(1.7)", 
+                                transformOrigin: "center center", 
+                                //border: "1px solid grey",
+                              }} 
+                              //checked={isChecked}
+                              //onChange={handleChange} 
+                            />
                             </td>
                           </tr>
                         ))}

--- a/frontend/src/components/DocumentLayoutCreate.tsx
+++ b/frontend/src/components/DocumentLayoutCreate.tsx
@@ -173,6 +173,9 @@ function DocumentLayoutCreate() {
 
   const editAnotation = (index: number) => {
     setEditingIndex(index); 
+    if(annotations.length > 0 && !annotations[annotations.length - 1].saved) {
+      annotations.pop();
+    }
     const res = instanceEditAnotation(index, annotations);
     const annotationToEdit = res;
     setFieldName(annotationToEdit.name || ""); 
@@ -408,7 +411,7 @@ function DocumentLayoutCreate() {
             style={{
               marginLeft: "50px",
               minWidth: `${canvasMeasures.width}px`,
-              marginRight: "20px",
+              marginRight: "30px",
             }}
           >
             <div
@@ -508,7 +511,7 @@ function DocumentLayoutCreate() {
               {annotations.filter((annotation) => annotation.saved).length > 0 && (
                 <div className="mt-3">
                   <h5>Added Fields:</h5>
-                  <Table striped bordered hover style={{ maxWidth: '560px' }}>
+                  <Table striped bordered hover style={{ maxWidth: '570px' }}>
                     <thead>
                       <tr>
                         <th>#</th>

--- a/frontend/src/components/DocumentLayoutCreate.tsx
+++ b/frontend/src/components/DocumentLayoutCreate.tsx
@@ -236,6 +236,7 @@ function DocumentLayoutCreate() {
         name: annotation.name,
         upper_left: [annotation.shapeProps.x, annotation.shapeProps.y],
         lower_right: [annotation.shapeProps.x + annotation.shapeProps.width, annotation.shapeProps.y + annotation.shapeProps.height],
+        is_multiline: annotation.isMultiline
       };
     });
 
@@ -460,7 +461,7 @@ function DocumentLayoutCreate() {
           <Col
             md={6}
             className="responsive-col mx-auto"
-            style={{ width: "550px"}}
+            style={{ width: "570px"}}
           >
             <div className="mt-3">
               <Button variant="success" onClick={showLayoutForm}  className="me-2">Save Layout</Button>
@@ -507,7 +508,7 @@ function DocumentLayoutCreate() {
               {annotations.filter((annotation) => annotation.saved).length > 0 && (
                 <div className="mt-3">
                   <h5>Added Fields:</h5>
-                  <Table striped bordered hover>
+                  <Table striped bordered hover style={{ maxWidth: '560px' }}>
                     <thead>
                       <tr>
                         <th>#</th>
@@ -523,11 +524,11 @@ function DocumentLayoutCreate() {
                         .map((annotation, index) => (
                           <tr key={index}>
                             <td className="text-start align-middle">{index + 1}</td>
-                            <td className="text-start align-middle">{annotation.name || "Unnamed Field"}</td>
+                            <td className="text-start align-middle" style={{ maxWidth: '180px', wordWrap: 'break-word', overflowWrap: 'break-word' }}>{annotation.name || "Unnamed Field"}</td>
                             <td className="text-start align-middle">
-                            ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y))}),  
+                            ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y))}) <br />
                             ({Math.round(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {Math.round(Number(annotation.shapeProps.y))}) <br />
-                            ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))}), 
+                            ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))}) <br />
                             ({Math.round(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {Math.round(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))})
                             </td>
                             <td className="text-center align-middle" style={{ whiteSpace: "nowrap", padding: "0px 5px" }}>
@@ -561,8 +562,16 @@ function DocumentLayoutCreate() {
                               type="checkbox"
                               className="custom-checkbox"
                               style={{ padding: "5px" }}
-                              //checked={isChecked}
-                              //onChange={handleChange} 
+                              checked={ annotation.isMultiline }
+                              onChange={() => {
+                                const updatedAnnotations = [...annotations];
+                                updatedAnnotations[index] = {
+                                  ...updatedAnnotations[index],
+                                  isMultiline: !updatedAnnotations[index].isMultiline
+                                };
+                                setAnnotations(updatedAnnotations);
+                              }}
+                              disabled={ editingIndex != null } 
                             />
                             </td>
                           </tr>

--- a/frontend/src/components/DocumentLayoutCreate.tsx
+++ b/frontend/src/components/DocumentLayoutCreate.tsx
@@ -559,11 +559,8 @@ function DocumentLayoutCreate() {
                             <td style={{ textAlign: "center", verticalAlign: "middle" }}>
                             <Form.Check 
                               type="checkbox"
-                              style={{ 
-                                transform: "scale(1.7)", 
-                                transformOrigin: "center center", 
-                                //border: "1px solid grey",
-                              }} 
+                              className="custom-checkbox"
+                              style={{ padding: "5px" }}
                               //checked={isChecked}
                               //onChange={handleChange} 
                             />

--- a/frontend/src/components/DocumentLayoutEdit.tsx
+++ b/frontend/src/components/DocumentLayoutEdit.tsx
@@ -57,6 +57,7 @@ function DocumentLayoutEdit() {
                   saved: true,
                   isSelected: false,
                   onChange: () => {},
+                  isMultiline: field.is_multiline,
                 };
             });
 
@@ -191,6 +192,9 @@ function DocumentLayoutEdit() {
 
     const editAnotation = (index: number) => {
         setEditingIndex(index); 
+        if(annotations.length > 0 && !annotations[annotations.length - 1].saved) {
+            annotations.pop();
+        }
         const res = instanceEditAnotation(index, annotations);
         const annotationToEdit = res;
         setFieldName(annotationToEdit.name || ""); 
@@ -272,6 +276,7 @@ function DocumentLayoutEdit() {
             name: annotation.name,
             upper_left: [annotation.shapeProps.x, annotation.shapeProps.y],
             lower_right: [annotation.shapeProps.x + annotation.shapeProps.width, annotation.shapeProps.y + annotation.shapeProps.height],
+            is_multiline: annotation.isMultiline
           };
         });
     
@@ -285,8 +290,6 @@ function DocumentLayoutEdit() {
         setWaitingForSave(true);
         putDocumentLayout(layoutName, fields);
     }
-
-    const roundToTwo = (x: number) => Math.round(x * 100) / 100
 
     const discardChanges = () => {
         setAnnotations(initialAnnotations);
@@ -332,11 +335,12 @@ function DocumentLayoutEdit() {
             <Row className="d-flex flex-wrap justify-content-center align-items-start">
             {/* Canvas Column */}
             <Col
-                md={7}
+                md={6}
                 className="responsive-col"
                 style={{
                 marginLeft: "50px",
                 minWidth: `${canvasMeasures.width}px`,
+                marginRight: "30px",
                 }}
             >
                 <div
@@ -387,9 +391,9 @@ function DocumentLayoutEdit() {
 
             {/* Form Column */}
             <Col
-                md={5}
+                md={6}
                 className="responsive-col mx-auto"
-                style={{ width: "550px"}}
+                style={{ width: "570px"}}
             >
                 <div className="mt-3">
                 <Button variant="success" onClick={showLayoutForm}  className="me-2">Save Layout</Button>
@@ -436,13 +440,14 @@ function DocumentLayoutEdit() {
                 {annotations.filter((annotation) => annotation.saved).length > 0 && (
                     <div className="mt-3">
                     <h5>Added Fields:</h5>
-                    <Table striped bordered hover>
+                    <Table striped bordered hover style={{ maxWidth: '570px' }}>
                         <thead>
                         <tr>
                             <th>#</th>
                             <th>Field Name</th>
                             <th>Field Coordinates</th>
-                            <th >Actions</th>
+                            <th>Actions</th>
+                            <th>Multi-line</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -451,14 +456,14 @@ function DocumentLayoutEdit() {
                             .map((annotation, index) => (
                             <tr key={index}>
                                 <td className="text-start align-middle">{index + 1}</td>
-                                <td className="text-start align-middle">{annotation.name || "Unnamed Field"}</td>
+                                <td className="text-start align-middle" style={{ maxWidth: '180px', wordWrap: 'break-word', overflowWrap: 'break-word' }}>{annotation.name || "Unnamed Field"}</td>
                                 <td className="text-start align-middle">
-                                ({roundToTwo(Number(annotation.shapeProps.x))}, {roundToTwo(Number(annotation.shapeProps.y))}),  
-                                ({roundToTwo(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {roundToTwo(Number(annotation.shapeProps.y))}) <br />
-                                ({roundToTwo(Number(annotation.shapeProps.x))}, {roundToTwo(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))}), 
-                                ({roundToTwo(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {roundToTwo(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))})
+                                ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y))}) <br />
+                                ({Math.round(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {Math.round(Number(annotation.shapeProps.y))}) <br />
+                                ({Math.round(Number(annotation.shapeProps.x))}, {Math.round(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))}) <br />
+                                ({Math.round(Number(annotation.shapeProps.x) + Number(annotation.shapeProps.width))}, {Math.round(Number(annotation.shapeProps.y) + Number(annotation.shapeProps.height))})
                                 </td>
-                                <td className="text-center align-middle" style={{ whiteSpace: "nowrap" }}>
+                                <td className="text-center align-middle" style={{ whiteSpace: "nowrap", padding: "0px 5px" }}>
                                 <Button 
                                     variant="primary"
                                     className="me-2"
@@ -484,6 +489,24 @@ function DocumentLayoutEdit() {
                                 >
                                     Delete
                                 </Button>
+                                </td>
+                                <td style={{ textAlign: "center", verticalAlign: "middle" }}>
+                                <Form.Check 
+                                    type="checkbox"
+                                    className="custom-checkbox"
+                                    style={{ padding: "5px" }}
+                                    checked={ annotation.isMultiline }
+                                    onChange={() => {
+                                        const updatedAnnotations = [...annotations];
+                                        updatedAnnotations[index] = {
+                                            ...updatedAnnotations[index],
+                                            isMultiline: !updatedAnnotations[index].isMultiline
+                                        };
+                                        setAnnotations(updatedAnnotations);
+                                        setChangesMade(true);
+                                    }}
+                                    disabled={ editingIndex != null } 
+                                />
                                 </td>
                             </tr>
                             ))}


### PR DESCRIPTION
Napomena: Što se tiče izmjena na FE vezano za odnos type-layout (sada je 1-1), to tek treba biti implementirano na drugom branchu (issue #99). Ovdje je trenutno dodan checkbox za oznaku da li je neko polje multi-line i pamćenje toga u okviru `fields` u tabeli `document_layouts`. Razlog zašto ovdje na pregledu document layout-a više ne stoji ispravan tip je što je u ovaj branch već merge-an `dev` na kojem se nalaze navedene izmjene na BE.